### PR TITLE
Implement no_std support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ assert_eq!(get_canonical_combining_class('\u{18A9}'), CanonicalCombiningClass::A
 
 */
 
+#![no_std]
 #![doc(html_root_url = "https://docs.rs/unicode-ccc/0.1.0")]
 
 #![forbid(unsafe_code)]


### PR DESCRIPTION
It just needs the attribute.

Turns out that rustybuzz's dependencies aren't actually no_std compatible, so those need a few PRs as well. On the bright side, with those I was able to make rustybuzz and tiny-skia work perfectly well on the GBA :D

![https://i.imgur.com/5wEko1P.png](https://i.imgur.com/5wEko1P.png)