### PR TITLE
Parse Iota_Subscript correctly.

### DIFF
--- a/gen-unicode-ccc.py
+++ b/gen-unicode-ccc.py
@@ -38,6 +38,7 @@ with open(FILE_NAME) as f:
             ranges.append([start, end])
         else:
             ranges.append([range, None])
+    classes[last_class] = ranges
 
 for class_name, ranges in classes.items():
     if class_name == 'NotReordered':

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -463,6 +463,7 @@ pub fn get_canonical_combining_class(c: char) -> CanonicalCombiningClass {
         0x035D..=0x035E => DoubleAbove,
         0x0360..=0x0361 => DoubleAbove,
         0x1DCD => DoubleAbove,
+        0x0345 => IotaSubscript,
         _ => NotReordered,
     }
 }


### PR DESCRIPTION
Fixes a bug in the script, where the final class in `DerivedCombiningClass.txt` is never generated.